### PR TITLE
Add React 17 as valid peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "prepare": "webpack"
   },
   "peerDependencies": {
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react": "^16.13.1 || ^17.0.0",
+    "react-dom": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.7.5",


### PR DESCRIPTION
This will remove warnings when installing with yarn and not force you to use `--legacy-peer-deps` when installing with npm!