### PR TITLE
Share goTrueToken in hook.

### DIFF
--- a/src/useNetlifyIdentity.js
+++ b/src/useNetlifyIdentity.js
@@ -328,6 +328,7 @@ const useNetlifyIdentity = ({ url: _url }) => {
     pendingEmailUpdate,
     sendPasswordRecovery,
     completeUrlTokenTwoStep,
+    goTrueToken
   }
 }
 

--- a/src/useNetlifyIdentity.js
+++ b/src/useNetlifyIdentity.js
@@ -56,8 +56,13 @@ const useNetlifyIdentity = ({ url: _url }) => {
 
   // Thin wrapper around useState setter to inject expires_at
   const setGoTrueToken = useCallback(goTrueToken => {
-    const expires_at = new Date(JSON.parse(window.atob(goTrueToken.access_token.split('.')[1])).exp * 1000)
-    _setGoTrueToken({ ...goTrueToken, expires_at })
+    _setGoTrueToken(goTrueToken?.access_token
+      ? {
+        ...goTrueToken,
+        expires_at: new Date(JSON.parse(window.atob(goTrueToken.access_token.split('.')[1])).exp * 1000)
+      }
+      : goTrueToken
+    )
   }, [])
 
   // STUB - Exclusively refreshes the goTrueToken (doesn't touch user) -- 


### PR DESCRIPTION
Sharing goTrueToken provides a way to authenticate requests made without the provided fetch.
Allowing, for example, graphql queries to be authenticated.